### PR TITLE
add separate takeout page section

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,8 +70,6 @@ def submit():
     lipoti = request.form.get("lipoti", "Placeholder")
     takeout = request.form.get("takeout", "Placeholder")
 
-    print(takeout)
-
     # if it is a takeout order, set mode to 0 if not set to mode
     if takeout == "takeout":
         takeout = 1

--- a/app.py
+++ b/app.py
@@ -124,7 +124,7 @@ def return_todays_orders():
 
     def squash_orders(name):
         items = [order.order for order in orders if order.name == name]
-        result = ",".join(items)
+        result = ", ".join(items)
         return result
 
     users_orders = []

--- a/app.py
+++ b/app.py
@@ -140,7 +140,13 @@ def return_todays_orders():
             )
             users_orders.append(user_order)
 
-    return render_template("today_orders.html", orders=users_orders)
+    buckets = [[], []]  # index 0 -> dine-in, index 1 -> takeout
+    for uo in users_orders:
+        buckets[uo.takeout].append(uo)
+
+    return render_template("today_orders.html",
+                           dinein_orders=buckets[0],
+                           takeout_orders=buckets[1] )
 
 @app.route("/car_distribution")
 def return_car_distribution():

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
 
         <br><br>
 
-        <label for="order">Order Description(200 char max):</label>
+        <label for="order">Order Description (200 char max):</label>
         <input type="text" id="order" name="order" required>
 
         <br><br>

--- a/templates/today_orders.html
+++ b/templates/today_orders.html
@@ -10,9 +10,10 @@
     <h2>DineIn Orders</h2>
     <ol style="word-break: break-all;">
         {% for user_obj in dinein_orders %}
-                <span class="pico-color-red-450">{{ user_obj.name }}</span>
-
-                ordered: <span class="pico-color-red-450">{{ user_obj.order }}</span>
+        <li>
+            <span class="pico-color-red-450">{{ user_obj.name }}</span>
+            ordered: <span class="pico-color-red-450">{{ user_obj.order }}</span>
+        </li>
         {% endfor %}
     </ol>
     <h2>Takeout Orders</h2>

--- a/templates/today_orders.html
+++ b/templates/today_orders.html
@@ -7,9 +7,19 @@
 {%block body %}
 
 <div class ="content">
-    <h2>Today's Orders</h2>
+    <h2>DineIn Orders</h2>
     <ol style="word-break: break-all;">
-        {% for user_obj in orders %}
+        {% for user_obj in dinein_orders %}
+           <li {% if user_obj.takeout %}style="font-style: italic;"{% endif %}>
+                <span class="pico-color-red-450">{{ user_obj.name }}</span>
+
+                ordered: <span class="pico-color-red-450">{{ user_obj.order }}</span>
+            </li>
+        {% endfor %}
+    </ol>
+    <h2>Takeout Orders</h2>
+    <ol style="word-break: break-all;">
+        {% for user_obj in takeout_orders %}
            <li {% if user_obj.takeout %}style="font-style: italic;"{% endif %}>
                 <span class="pico-color-red-450">{{ user_obj.name }}</span>
 
@@ -18,18 +28,6 @@
                 Takeout: <span class="pico-color-red-450">YES
                 </span>
                 {% endif %}
-
-                <!-- Transportation: <span class="pico-color-red-450">
-                    {% if user_obj.t_mode == 1 %}
-                        Has a car and will drive people from office.
-                    {% elif user_obj.t_mode == 2  %}
-                        Wants to be driven by someone from office.
-                    {% elif user_obj.t_mode == 3  %}
-                        Will come by himself.
-                    {% else %}
-                        Ordered Takeout.
-                    {% endif %}
-                </span> -->
 
             </li>
         {% endfor %}

--- a/templates/today_orders.html
+++ b/templates/today_orders.html
@@ -10,11 +10,9 @@
     <h2>DineIn Orders</h2>
     <ol style="word-break: break-all;">
         {% for user_obj in dinein_orders %}
-           <li {% if user_obj.takeout %}style="font-style: italic;"{% endif %}>
                 <span class="pico-color-red-450">{{ user_obj.name }}</span>
 
                 ordered: <span class="pico-color-red-450">{{ user_obj.order }}</span>
-            </li>
         {% endfor %}
     </ol>
     <h2>Takeout Orders</h2>


### PR DESCRIPTION
This pull request refactors how orders are displayed and organized in the application by separating dine-in and takeout orders. The main changes include updating the backend logic to categorize orders and modifying the frontend template to present these categories distinctly.

**Backend logic improvements:**

* Orders are now split into two buckets (`dinein_orders` and `takeout_orders`) based on the `takeout` attribute, and these are passed separately to the template for clearer presentation.

**Frontend template updates:**

* The `today_orders.html` template now displays "DineIn Orders" and "Takeout Orders" in separate sections, iterating over the respective lists and showing user details for each category.
* Removed the unused transportation information block from the order display to simplify the UI and focus on order type.

**Minor code cleanup:**

* Removed an unnecessary `print` statement from the `submit()` function for cleaner code.