### PR TITLE
add choosable lipoti driver

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -31,6 +31,19 @@ body {
     transition: max-height 1s ease-in-out;
 }
 
+/* LIPÓTI USER DRIVER OPTION */
+
+.lipotiUserDriverElement {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease-in-out;
+}
+
+.lipotiUserDriverElement.show {
+    max-height: 100vh;
+    transition: max-height 1s ease-in-out;
+}
+
 #version {
     position: absolute;
     top: 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,6 +60,20 @@
                     I will come by myself.
                 </label>
             </fieldset>
+            <!-- LIPOTI USER DRIVER OPTION -->
+            <fieldset>
+                <div class="lipotiUserDriverElement field-hidden">
+                    <legend>LIPÓTI USER DRIVER OPTION:</legend>
+                    <label>
+                        <input name="lipoti_d" value="1" type="radio" required />
+                        Yes, I want to be a driver for LIPÓTI.
+                    </label>
+                    <label>
+                        <input name="lipoti_d" value="0" type="radio" required />
+                        NO, I do not want to be a driver for LIPÓTI.
+                    </label>
+                </div>
+            </fieldset>
             <!-- LIPÓTI BAKERY -->
             <fieldset>
                 <div class="lipotisetElement field-hidden">
@@ -89,6 +103,9 @@
         const transportRadios = document.querySelectorAll('input[name="mode"]');
         const lipotisetElement = document.querySelector('.lipotisetElement');
         const lipotiRadios = document.querySelectorAll('input[name="lipoti"]');
+        // --- lipoti user driver logic ---
+        const lipotiUserDriverElement = document.querySelector('.lipotiUserDriverElement');
+        const lipotiUserDriverRadios = document.querySelectorAll('input[name="lipoti_d"]');
 
         // --- takeout radio logic ---
         if (target.name === "takeout") {
@@ -99,7 +116,9 @@
                 transportRadios.forEach(r => r.required = true);
             } else {
                 transportFieldset.classList.remove("show");
+                lipotiUserDriverElement.classList.remove("show");
                 lipotisetElement.classList.remove("show");
+
 
                 transportRadios.forEach(r => {
                     r.required = false;
@@ -111,7 +130,19 @@
                 });
             }
         }
-
+        // --- lipoti user driver logic ---
+        if (target.name === "mode") {
+            if (target.value === "1" && target.checked) {
+                lipotiUserDriverElement.classList.add("show");
+                lipotiUserDriverRadios.forEach(r => r.required = true);
+            } else {
+                lipotiUserDriverElement.classList.remove("show");
+                lipotiUserDriverRadios.forEach(r => {
+                    r.required = false;
+                    r.checked = false;
+                });
+            }
+        }
         // --- transport mode radio logic ---
         if (target.name === "mode") {
             if (target.value === "2" && target.checked) {


### PR DESCRIPTION
This pull request introduces a new feature allowing users to indicate if they want to be a driver for LIPÓTI, and refactors how driver selection is handled throughout the codebase. The changes span backend database models, request handling, frontend form logic, and styling to support this new option and improve the user experience.

**Backend changes:**

* Added a new `lipoti_d` column to the `Orders` database model to record whether a user wants to be a LIPÓTI driver.
* Implemented the `get_list_of_lipoti_drivers()` function to retrieve users who opted to be LIPÓTI drivers for the current day.
* Updated the order submission logic to include the `lipoti_d` field when creating an `Orders` record. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R111) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R129)
* Refactored driver selection in `return_car_distribution()` to use the new `lipoti_drivers` list instead of the deprecated `LIPOTI_DRIVERS` environment variable, improving reliability and maintainability. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R213-R214) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L231-R251)

**Frontend changes:**

* Added a new "LIPÓTI USER DRIVER OPTION" fieldset to the order form, allowing users to select whether they want to be a driver for LIPÓTI.
* Implemented JavaScript logic to show/hide the driver option based on the selected transport mode, and to manage required field validation. [[1]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R106-R108) [[2]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R119-R122) [[3]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L114-R145)
* Added CSS styles for the new driver option fieldset to ensure smooth transitions and a consistent user interface.