### PR TITLE
Add clear indication of unwanted takeout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -128,6 +128,10 @@
                     r.required = false;
                     r.checked = false;
                 });
+                lipotiUserDriverRadios.forEach(r => {
+                    r.required = false;
+                    r.checked = false;
+                });
             }
         }
         // --- lipoti user driver logic ---

--- a/templates/today_orders.html
+++ b/templates/today_orders.html
@@ -43,8 +43,12 @@
 
             ordered: <span class="pico-color-red-450">{{ user_obj.order }}</span>
             {% if user_obj.takeout %}
-            Takeout: <span class="pico-color-red-450">YES</span>
+                Preference: <span class="pico-color-red-450">Takeout</span>
+            {% else %}
+                Preference: <span class="pico-color-red-450">Dine-in</span>
+                → Assigned: <span class="pico-color-red-450">Takeout (no space)</span>
             {% endif %}
+
             <form action="/orders/delete" method="post" class="delete_button_wrapper" onsubmit="return confirm('Are you sure?');">
                 <input type="hidden" name="name" value="{{ user_obj.name }}">
                 <button type="submit" class="delete_button">


### PR DESCRIPTION
This pull request updates the order placement and order summary logic in the templates to improve clarity and consistency for users. The most important changes are grouped below:

Order placement logic:

* The script for handling order form radio buttons now resets both the main and `lipotiUserDriverRadios` groups, ensuring neither are required or checked when appropriate.

Order summary display:

* The takeout order summary in `today_orders.html` now displays a clearer preference label ("Preference: Takeout" or "Preference: Dine-in"). If a user prefers dine-in but is assigned takeout due to lack of space, this is explicitly shown ("→ Assigned: Takeout (no space)").